### PR TITLE
bump build-# and remove bogus ignore_run_exports

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+# the conda-build parameters to use for disabling --skip-existing
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,28 +26,27 @@ requirements:
     - meson >=0.55.3         # [not (osx and arm64)]
     - ninja-base
     # is disabled as this package contains wrong path configs
-    - gobject-introspection  # [not win]
+    - gobject-introspection 1.* # [not win]
     - perl                   # [win]
     - python
     - patch                  # [not win]
     - m2-patch               # [win]
   host:
-    - gobject-introspection  # [not win]
     - python
-    - gettext                # [osx]
+    - gettext 0.21.0  # [osx]
     - glib >=2.56.0
-    - jpeg
-    - libtiff
-    - libpng
-    - zlib
+    - jpeg 9e
+    - libtiff 4.2.0
+    - libpng 1.6.37
+    - zlib 1.2.13
     - libffi 3.4             # [win]
   run:
-    - gettext                # [osx]
+    - gettext >=0.21.0,<1.0a0  # [osx]
     - glib >=2.56.0
-    - jpeg
-    - libtiff
-    - libpng
-    - zlib
+    - jpeg >=9e,<10a
+    - libtiff >=4.2.0,<5.0a0
+    - libpng >=1.6.37,<1.7.0a0
+    - zlib >=1.2.13,<1.3.0a0
     - libffi >=3.4,<3.5       # [win]
 
 test:
@@ -80,7 +79,7 @@ about:
     modified, saved, or rendered.
     GdkPixbuf can load image data encoded in different formats, such as:
     PNG, JPEG, TIFF, TGA, GIF
-  doc_url: https://docs.gtk.org/gdk-pixbuf/
+  doc_url: https://docs.gtk.org/
   dev_url: https://gitlab.gnome.org/GNOME/gdk-pixbuf/
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,14 +13,10 @@ source:
       - 0001-changed-perl-script-to-use-env.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=gdk-pixbuf
     - {{ pin_subpackage('gdk-pixbuf', max_pin='x') }}
-  ignore_run_exports:
-    - zlib
-    - jpeg    # [win]
-    - libffi  # [win]
 
 requirements:
   build:


### PR DESCRIPTION
* bump build-#
* remove ignore_run_exports
* adjust pinnings in host, and removed gobject-introspection dependency from host

This feedstock seems to show an issue with linker, which thinks this package would be a python one, which actually is wrong