### PR TITLE
gdk-pixbuf 2.42.10: Rebuild against gettext and gobject-introspection 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -7,4 +7,3 @@ aggregate_branch: libxml_2.13.1
 
 channels:
   - https://staging.continuum.io/prefect/fs/gettext-feedstock/pr6/c7dfc15
-  - https://staging.continuum.io/prefect/fs/gobject-introspection-feedstock/pr12/cf8c5f9

--- a/abs.yaml
+++ b/abs.yaml
@@ -6,4 +6,5 @@ build_parameters:
 aggregate_branch: libxml_2.13.1
 
 channels:
-  - https://staging.continuum.io/prefect/fs/gettext-feedstock/pr6/c7dfc15
+  - https://staging.continuum.io/prefect/fs/libxml2-feedstock/pr17/1c2e862
+  - https://staging.continuum.io/prefect/fs/gettext-feedstock/pr6/c7aa8c4

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,9 +2,3 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-
-aggregate_branch: libxml_2.13.1
-
-channels:
-  - https://staging.continuum.io/prefect/fs/libxml2-feedstock/pr17/1c2e862
-  - https://staging.continuum.io/prefect/fs/gettext-feedstock/pr6/c7aa8c4

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,8 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
+aggregate_branch: libxml_2.13.1
+
+channels:
+  - https://staging.continuum.io/prefect/fs/gettext-feedstock/pr6/c7dfc15
+  - https://staging.continuum.io/prefect/fs/gobject-introspection-feedstock/pr12/cf8c5f9

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
       - 0001-changed-perl-script-to-use-env.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=gdk-pixbuf
     - {{ pin_subpackage('gdk-pixbuf', max_pin='x') }}


### PR DESCRIPTION

**Destination channel:** main

### Links

- [PKG-5411](https://anaconda.atlassian.net/browse/PKG-5411) 
- [Upstream repository]()

### Explanation of changes:

- Bump the buid number to `1`

### Notes:

- I got an error when building librsvg (see [PR](https://github.com/AnacondaRecipes/librsvg-feedstock/pull/5)):
`g_module_open() failed for C:\b\abs_13s8a4yyat\croot\librsvg_1721991169555\_h_env\Library\lib\gdk-pixbuf-2.0\2.10.0\loaders\pixbufloader-xbm.dll: 'C:\b\abs_13s8a4yyat\croot\librsvg_1721991169555\_h_env\Library\lib\gdk-pixbuf-2.0\2.10.0\loaders\pixbufloader-xbm.dll': The specified module could not be found.`
  - That means that something is wrong with `gdk-pixbuf`. As it depends on `gettext` we need to rebuild it with `libxml2 2.13` -> `gettext` (from the staging channel), see https://github.com/AnacondaRecipes/gettext-feedstock/pull/6
- Also rebuilding against https://github.com/AnacondaRecipes/gobject-introspection-feedstock/pull/12

[PKG-5411]: https://anaconda.atlassian.net/browse/PKG-5411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ