### PR TITLE
gdk-pixbuf 2.42.10: Rebuild with libtiff 4.7.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,6 +2,3 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-
-channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,4 +4,4 @@ build_parameters:
   - "--error-overlinking"
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,6 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
+
+channels:
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,4 +4,4 @@ build_parameters:
   - "--error-overlinking"
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,4 +4,4 @@ build_parameters:
   - "--error-overlinking"
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     # https://github.com/pypa/setuptools/pull/3505
     - setuptools <65
   host:
+    - setuptools <65  # [osx and arm64]
     - pkg-config
     - ninja
     - perl 5.* # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,8 @@ requirements:
     - m2-patch               # [win]
     - gawk  # [not win]
     - sed   # [not win]
+    # run-dep as a workaround for now; upstream package still imports from distutils
+    - setuptools <74  # [py>311]
   host:
     - pkg-config
     - ninja

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,9 @@ requirements:
     - m2-patch               # [win]
     - gawk  # [not win]
     - sed   # [not win]
-    # run-dep as a workaround for now; upstream package still imports from distutils
-    - setuptools <74  # [py>311]
+    # setuptools >= 65.0.0 is lacking the msvccompiler module in distutils.
+    # https://github.com/pypa/setuptools/pull/3505
+    - setuptools <65
   host:
     - pkg-config
     - ninja

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,6 @@ source:
 
 build:
   number: 2
-  skip: true  # [s390x]
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=gdk-pixbuf
     - {{ pin_subpackage('gdk-pixbuf', max_pin='x') }}
@@ -44,18 +43,18 @@ requirements:
     - libiconv                # [osx or win]
     - glib {{ glib }}
     - jpeg {{ jpeg }}
-    - libtiff 4.7.0
+    - libtiff {{ libtiff }}
     - libpng {{ libpng }}
     - zlib {{ zlib }}
     - libffi {{ libffi }}      # [win]
   run:
-    - gettext >=0.21.0,<1.0a0  # [osx]
-    - glib >=2.56.0
-    - jpeg >=9e,<10a
-    - libtiff >=4.2.0,<5.0a0
-    - libpng >=1.6.39,<1.7.0a0
-    - zlib >=1.2.13,<1.3.0a0
-    - libffi >=3.4,<3.5       # [win]
+    - gettext  # [osx]
+    - glib
+    - jpeg
+    - libtiff
+    - libpng
+    - zlib
+    - libffi       # [win]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 
 build:
   number: 2
+  skip: true  # [s390x]
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=gdk-pixbuf
     - {{ pin_subpackage('gdk-pixbuf', max_pin='x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
       - 0001-changed-perl-script-to-use-env.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=gdk-pixbuf
     - {{ pin_subpackage('gdk-pixbuf', max_pin='x') }}
@@ -29,21 +29,21 @@ requirements:
   host:
     - pkg-config
     - ninja
-    - perl  # [win]
+    - perl 5.* # [win]
     - docutils
     - gi-docgen
     - gobject-introspection 1.*
     - python
-    - meson ==0.56.2         # [(osx and arm64)]
-    - meson >=0.55.3         # [not (osx and arm64)]
-    - gettext 0.21.0  # [osx]
-    - libiconv   # [osx or win]
-    - glib >=2.60.0
-    - jpeg 9e
-    - libtiff 4.2.0
-    - libpng 1.6.39
-    - zlib 1.2.13
-    - libffi 3.4             # [win]
+    - meson ==0.56.2          # [(osx and arm64)]
+    - meson >=0.55.3          # [not (osx and arm64)]
+    - gettext 0.21.0          # [osx]
+    - libiconv                # [osx or win]
+    - glib {{ glib }}
+    - jpeg {{ jpeg }}
+    - libtiff 4.7.0
+    - libpng {{ libpng }}
+    - zlib {{ zlib }}
+    - libffi {{ libffi }}      # [win]
   run:
     - gettext >=0.21.0,<1.0a0  # [osx]
     - glib >=2.56.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,9 +29,9 @@ requirements:
     - sed   # [not win]
     # setuptools >= 65.0.0 is lacking the msvccompiler module in distutils.
     # https://github.com/pypa/setuptools/pull/3505
-    - setuptools <65
+    - setuptools <74  # [osx and arm64]
   host:
-    - setuptools <65  # [osx and arm64]
+    - setuptools <74  # [osx and arm64]
     - pkg-config
     - ninja
     - perl 5.* # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,10 +27,9 @@ requirements:
     - m2-patch               # [win]
     - gawk  # [not win]
     - sed   # [not win]
+  host:
     # setuptools >= 65.0.0 is lacking the msvccompiler module in distutils.
     # https://github.com/pypa/setuptools/pull/3505
-    - setuptools <74  # [osx and arm64]
-  host:
     - setuptools <74  # [osx and arm64]
     - pkg-config
     - ninja

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ requirements:
     - libffi {{ libffi }}      # [win]
   run:
     - gettext  # [osx]
-    - glib
+    - glib >=2.56.0
     - jpeg
     - libtiff
     - libpng


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7585](https://anaconda.atlassian.net/browse/PKG-7585) 
- [Upstream repository](https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/tree/2.42.10?ref_type=tags)

### Explanation of changes:

- Bump the build number to 2
- Add `setuptools <74  # [osx and arm64]` to `build` and `host`. If it's only in build, then it fails
- Pin host deps

### Notes:

-

[PKG-7585]: https://anaconda.atlassian.net/browse/PKG-7585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ