### PR TITLE
gdk-pixbuf 2.44.4

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -16,7 +16,7 @@ set PATH=%LIBRARY_BIN%;%PREFIX%\bin;%PATH%
 :: meson options
 :: (set pkg_config_path so deps in host env can be found)
 :: introspection disabled for now.
-set "MESON_OPTIONS=^
+set ^"MESON_OPTIONS=^
   --prefix="%LIBRARY_PREFIX%" ^
   --wrap-mode=nofallback ^
   --backend=ninja ^
@@ -27,7 +27,7 @@ set "MESON_OPTIONS=^
   -Dintrospection=enabled ^
   -Ddocumentation=false ^
   -Dtests=false ^
-  -Dinstalled_tests=false"
+  -Dinstalled_tests=false"^
 
 meson setup --help
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -19,15 +19,16 @@ set PATH=%LIBRARY_BIN%;%PREFIX%\bin;%PATH%
 set ^"MESON_OPTIONS=^
   --prefix="%LIBRARY_PREFIX%" ^
   --wrap-mode=nofallback ^
-  --buildtype=release ^
   --backend=ninja ^
   -Dc_std=c99 ^
   -Dgtk_doc=false ^
-  -Dinstalled_tests=false ^
   -Dman=false ^
   -Drelocatable=true ^
   -Dintrospection=enabled ^
-  -D docs=false ^
+  -Ddocumentation=false ^
+  -Dtests=false ^
+  -Dinstalled_tests=false ^
+
  ^"
 
 meson setup --help

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -27,7 +27,7 @@ set ^"MESON_OPTIONS=^
   -Dintrospection=enabled ^
   -Ddocumentation=false ^
   -Dtests=false ^
-  -Dinstalled_tests=false"^
+  -Dinstalled_tests=false"
 
 meson setup --help
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -16,7 +16,7 @@ set PATH=%LIBRARY_BIN%;%PREFIX%\bin;%PATH%
 :: meson options
 :: (set pkg_config_path so deps in host env can be found)
 :: introspection disabled for now.
-set ^"MESON_OPTIONS=^
+set "MESON_OPTIONS=^
   --prefix="%LIBRARY_PREFIX%" ^
   --wrap-mode=nofallback ^
   --backend=ninja ^
@@ -27,9 +27,7 @@ set ^"MESON_OPTIONS=^
   -Dintrospection=enabled ^
   -Ddocumentation=false ^
   -Dtests=false ^
-  -Dinstalled_tests=false ^
-
- ^"
+  -Dinstalled_tests=false"
 
 meson setup --help
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -17,17 +17,21 @@ fi
 export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
 
 meson_options_common=(
-    --buildtype=release
     --prefix="$PREFIX"
     --backend=ninja
     --wrap-mode=nofallback
+    -Dc_std=c99
     -Dgtk_doc=false
     -Dman=false
     -Dgio_sniffing=false
-    -Dinstalled_tests=false
     -Dlibdir=lib
     -Drelocatable=true
     -Dintrospection=enabled
+    -Ddocumentation=false
+    -Dtests=false
+    -Dinstalled_tests=false
+    -Dglycin=disabled
+
 )
 
 export PKG_CONFIG_PATH="${BUILD_PREFIX}/bin/pkg-config:${BUILD_PREFIX}/lib/pkgconfig:${PREFIX}/bin/pkg-config:${PREFIX}/lib/pkg-config"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,6 @@ requirements:
     - libtiff {{ libtiff }}
     - libpng {{ libpng }}
     - zlib {{ zlib }}
-    # - libffi {{ libffi }}      # [win]
   run:
     - glib >=2.56.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gdk-pixbuf" %}
-{% set version = "2.42.10" %}
-{% set sha256 = "ee9b6c75d13ba096907a2e3c6b27b61bcd17f5c7ebeab5a5b439d2f2e39fe44b" %}
+{% set version = "2.44.4" %}
+{% set sha256 = "93a1aac3f1427ae73457397582a2c38d049638a801788ccbd5f48ca607bdbd17" %}
 
 package:
     name: {{ name|lower }}
@@ -13,48 +13,35 @@ source:
       - 0001-changed-perl-script-to-use-env.patch
 
 build:
-  number: 2
+  number: 0
+  ignore_run_exports:
+    - glib
+    - zlib
+  missing_dso_whitelist:
+    - "*"
   run_exports:
     # https://abi-laboratory.pro/?view=timeline&l=gdk-pixbuf
     - {{ pin_subpackage('gdk-pixbuf', max_pin='x') }}
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
-    - binutils  # [linux]
-    - patch                  # [not win]
-    - m2-patch               # [win]
-    - gawk  # [not win]
-    - sed   # [not win]
-  host:
-    # setuptools >= 65.0.0 is lacking the msvccompiler module in distutils.
-    # https://github.com/pypa/setuptools/pull/3505
-    - setuptools <74  # [osx and arm64]
+    - meson >=1.5
     - pkg-config
     - ninja
+    - gettext  # [unix]
     - perl 5.* # [win]
-    - docutils
-    - gi-docgen
-    - gobject-introspection 1.*
-    - python
-    - meson ==0.56.2          # [(osx and arm64)]
-    - meson >=0.55.3          # [not (osx and arm64)]
-    - gettext 0.21.0          # [osx]
-    - libiconv                # [osx or win]
+  host:
+    - gobject-introspection
     - glib {{ glib }}
     - jpeg {{ jpeg }}
     - libtiff {{ libtiff }}
     - libpng {{ libpng }}
     - zlib {{ zlib }}
-    - libffi {{ libffi }}      # [win]
+    # - libffi {{ libffi }}      # [win]
   run:
-    - gettext  # [osx]
     - glib >=2.56.0
-    - jpeg
-    - libtiff
-    - libpng
-    - zlib
-    - libffi       # [win]
 
 test:
   requires:
@@ -75,7 +62,7 @@ test:
     - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix {{ pc }}`) do if not exist "%%a/{{ lib }}.lib" exit 1  # [win]
 
 about:
-  home: https://www.gtk.org/
+  home: https://www.gtk.org
   license: LGPL-2.1-or-later
   license_family: LGPL
   license_file: COPYING
@@ -86,8 +73,8 @@ about:
     modified, saved, or rendered.
     GdkPixbuf can load image data encoded in different formats, such as:
     PNG, JPEG, TIFF, TGA, GIF
-  doc_url: https://docs.gtk.org/
-  dev_url: https://gitlab.gnome.org/GNOME/gdk-pixbuf/
+  doc_url: https://docs.gtk.org
+  dev_url: https://gitlab.gnome.org/GNOME/gdk-pixbuf
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
gdk-pixbuf 2.44.4

**Destination channel:** {defaults}

### Links

jira | https://anaconda.atlassian.net/browse/PKG-11094
dev | https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/tree/2.44.4

### Explanation of changes:

- version bump 2.42.10 → 2.44.4
- meta.yaml cleanup: drop old host/tooling deps; keep gobject-introspection and core image libs
- build number reset 2 → 0
- bld.bat meson options cleaned; docs and tests disabled
- build.sh disables docs/tests, adds -Dglycin=disabled, keeps introspection enabled
