### PR TITLE
gdk-pixbuf 2.44.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - ninja
     - gettext  # [unix]
     - perl 5.* # [win]
+    - setuptools # [win]
   host:
     - gobject-introspection
     - glib {{ glib }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gdk-pixbuf" %}
-{% set version = "2.44.4" %}
-{% set sha256 = "93a1aac3f1427ae73457397582a2c38d049638a801788ccbd5f48ca607bdbd17" %}
+{% set version = "2.44.6" %}
+{% set sha256 = "140c2d0b899fcf853ee92b26373c9dc228dbcde0820a4246693f4328a27466fa" %}
 
 package:
     name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,8 @@ requirements:
     - ninja
     - gettext     # [unix]
     - perl 5.*    # [win]
-    # Needed for distutils used by g-ir-scanner on Python 3.12+
-    - setuptools  # [win and py==312]
+    # Needed for distutils used by g-ir-scanner
+    - setuptools  # [win]
   host:
     - gobject-introspection
     - glib {{ glib }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,9 +30,10 @@ requirements:
     - meson >=1.5
     - pkg-config
     - ninja
-    - gettext  # [unix]
-    - perl 5.* # [win]
-    - setuptools # [win]
+    - gettext     # [unix]
+    - perl 5.*    # [win]
+    # Needed for distutils used by g-ir-scanner on Python 3.12+
+    - setuptools  # [win and py==312]
   host:
     - gobject-introspection
     - glib {{ glib }}


### PR DESCRIPTION
gdk-pixbuf 2.44.6

**Destination channel:** {defaults}

### Links

jira | https://anaconda.atlassian.net/browse/PKG-13593
dev | https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/tree/2.44.6

### Explanation of changes:

- version bump 2.44.4 -> 2.44.6
- CVE
- added build: setuptools needed for meson