### PR TITLE
Rebuild against libjpeg-turbo

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,18 @@
 {% set name = "gdk-pixbuf" %}
 {% set version = "2.44.6" %}
-{% set sha256 = "140c2d0b899fcf853ee92b26373c9dc228dbcde0820a4246693f4328a27466fa" %}
 
 package:
     name: {{ name|lower }}
     version: {{ version }}
 
 source:
-    sha256: {{ sha256 }}
+    sha256: 140c2d0b899fcf853ee92b26373c9dc228dbcde0820a4246693f4328a27466fa
     url: https://download.gnome.org/sources/{{ name }}/{{ '.'.join(version.split('.')[:2]) }}/{{ name }}-{{ version }}.tar.xz
     patches:
       - 0001-changed-perl-script-to-use-env.patch
 
 build:
-  number: 0
+  number: 1
   ignore_run_exports:
     - glib
     - zlib
@@ -29,7 +28,7 @@ requirements:
     - {{ compiler('c') }}
     - meson >=1.5
     - pkg-config
-    - ninja
+    - ninja-base
     - gettext     # [unix]
     - perl 5.*    # [win]
     # Needed for distutils used by g-ir-scanner
@@ -37,7 +36,7 @@ requirements:
   host:
     - gobject-introspection
     - glib {{ glib }}
-    - jpeg {{ jpeg }}
+    - libjpeg-turbo {{ libjpeg_turbo }}
     - libtiff {{ libtiff }}
     - libpng {{ libpng }}
     - zlib {{ zlib }}


### PR DESCRIPTION
gdk-pixbuf 2.44.6

**Destination channel:**  defaults

### Links

- [PKG-13230](https://anaconda.atlassian.net/browse/PKG-13230) 
- [Upstream repository](https://gitlab.gnome.org/GNOME/gdk-pixbuf)

### Explanation of changes:
- Rebuild with libjpeg-turbo


[PKG-13230]: https://anaconda.atlassian.net/browse/PKG-13230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ